### PR TITLE
Fix tags page collection usage

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,7 +4,8 @@ import EntriesOne from "@/components/entries/EntriesOne.astro";
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-  const allPosts = await getCollection('blog'); // 👈 Replace 'blog' with your actual collection name
+  // Use the actual collection name defined in `src/content.config.ts`
+  const allPosts = await getCollection('posts');
 
   const tagsData = {};
   allPosts.forEach(post => {
@@ -60,7 +61,7 @@ const { posts } = Astro.props;
               alt={post.data.title}
               pubDate={post.data.pubDate.toString().slice(0, 10)}
               author={post.data.author}
-              image={post.data.image.url}
+              image={post.data.image?.url}
               tags={post.data.tags}
             />
           ))


### PR DESCRIPTION
## Summary
- fix incorrect content collection name on tag pages
- avoid runtime error when posts have no image

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fd216e8248327a8f4fe509c7e5e5c