### PR TITLE
Fix GA tag script inline

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,11 +26,10 @@ const {
   
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q6SPH61QXQ"></script>
-    <script>
+    <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-Q6SPH61QXQ');
     </script>
 


### PR DESCRIPTION
## Summary
- update BaseLayout to use `is:inline` for GA script so it's inserted without type=module

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840360fc0b88327a23fda59582042b7