### PR TITLE
Fix build permission error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "postinstall": "chmod +x node_modules/.bin/*"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.0.5",


### PR DESCRIPTION
## Summary
- add a postinstall step that marks all executables in `node_modules/.bin` as executable

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c5345ba648327943b41dc48a0365e