### PR TITLE
Allow optional descriptions

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,7 +4,7 @@ const posts = defineCollection({
   type: 'content', // use Astro's built‑in MD/MDX loader
   schema: z.object({
     title: z.string(),
-    description: z.string(),
+    description: z.string().optional(),
     pubDate: z.coerce.date(),
     author: z.string().optional(),
     tags: z.array(z.string()).default([]),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -4,7 +4,7 @@ const postsCollection = defineCollection({
     schema: z.object({
       title: z.string(),
       pubDate: z.date(),
-      description: z.string(),
+      description: z.string().optional(),
       author: z.string(),
 
       image: z.object({


### PR DESCRIPTION
## Summary
- allow optional descriptions in both `content` configuration files

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cc1ba580883279ebe84f1b0bdafd6