### PR TITLE
Improve post card and hero image layout

### DIFF
--- a/src/components/entries/EntriesOne.astro
+++ b/src/components/entries/EntriesOne.astro
@@ -36,7 +36,7 @@ const isoDateString = pubDate ? new Date(pubDate).toISOString() : ''; // datetim
     <article class="flex-1 flex flex-col bg-white shadow-sm hover:shadow-md transition-shadow duration-300 rounded-lg overflow-hidden">
       {/* Image Section - Only show if image exists */}
       {hasImage && (
-        <div class="block w-full aspect-[3/2] overflow-hidden">
+        <div class="block w-full aspect-square overflow-hidden">
           <img
             class="object-cover bg-center h-full w-full group-hover:scale-105 transition-transform duration-300"
             src={displayImage}

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -60,13 +60,15 @@ const shouldShowDescription = frontmatter.description && frontmatter.description
       <div class="lg:text-center">
         {/* Use heroImage if it exists */}
         {frontmatter.heroImage && (
-            <img
-              src={frontmatter.heroImage}
-              alt={frontmatter.title || '게시글 대표 이미지'}
-              class="lg:h-96 w-full object-cover object-center mb-8 rounded-lg shadow-md"
-              loading="lazy"
-              onerror="this.style.display='none';"
-          />
+            <div class="w-full aspect-[16/5] overflow-hidden mb-8">
+              <img
+                src={frontmatter.heroImage}
+                alt={frontmatter.title || '게시글 대표 이미지'}
+                class="object-cover object-center w-full h-full"
+                loading="lazy"
+                onerror="this.style.display='none';"
+              />
+            </div>
         )}
         <div class="flex flex-col md:flex-row mt-4 justify-between items-center mb-8">
           {/* Display Date */}


### PR DESCRIPTION
## Summary
- adjust post list cards to display square images
- show hero images in a panoramic ratio on post pages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877545a6e448327804d02f0a1099867