### PR TITLE
feat: show hero image across posts

### DIFF
--- a/src/components/entries/EntriesOne.astro
+++ b/src/components/entries/EntriesOne.astro
@@ -39,9 +39,9 @@ const isoDateString = dateToUse ? new Date(dateToUse).toISOString() : '';
     <article class="flex-1 flex flex-col bg-white shadow-sm hover:shadow-md transition-shadow duration-300 rounded-lg overflow-hidden">
       {/* Image Section - Only show if image exists */}
       {hasImage && (
-        <div class="block w-full aspect-[16/9] overflow-hidden">
+        <div class="block w-full overflow-hidden rounded-t-lg aspect-[16/9]">
           <img
-            class="object-cover bg-center h-full w-full group-hover:scale-105 transition-transform duration-300"
+            class="h-full w-full object-cover bg-center transition-transform duration-300 group-hover:scale-105"
             src={displayImage}
             alt={displayAlt}
             loading="lazy"

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -4,14 +4,15 @@ import BaseLayout from "./BaseLayout.astro"; // Ensure path is correct
 import { AstroSeo } from "@astrolib/seo"; // Assuming you still use this
 
 const { frontmatter } = Astro.props;
-const hasHero = !!frontmatter.heroImage;
+const heroSrc = frontmatter.heroImage || frontmatter.image?.url;
+const hasHero = !!heroSrc;
 
 // --- SEO Data ---
 const pageTitle = frontmatter.title || "낱말로 쌓은 성성";
 const pageDescription = frontmatter.description || "블로그 게시글";
 const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
-const ogImageURL = frontmatter.heroImage
-  ? new URL(frontmatter.heroImage, Astro.site).toString()
+const ogImageURL = heroSrc
+  ? new URL(heroSrc, Astro.site).toString()
   : new URL("/default-og-image.jpg", Astro.site).toString(); // Default OG image
 
 // 설명(description)이 실제로 존재하고, 기본 안내 문구가 아닌 경우에만 true
@@ -61,17 +62,15 @@ const shouldShowDescription =
 >
   <section>
     {hasHero && (
-      <div class="mx-auto max-w-7xl mb-8">
-        <div class="w-full aspect-[16/5] overflow-hidden">
-          <img
-            src={frontmatter.heroImage}
-            alt={frontmatter.title || '게시글 대표 이미지'}
-            class="object-cover object-center w-full h-full"
-            loading="lazy"
-            onerror="this.style.display='none';"
-          />
-        </div>
-      </div>
+      <figure class="mx-auto max-w-7xl mb-8">
+        <img
+          src={heroSrc}
+          alt={frontmatter.image?.alt || frontmatter.title || '게시글 대표 이미지'}
+          class="w-full h-auto object-cover object-center rounded-lg"
+          loading="lazy"
+          onerror="this.style.display='none';"
+        />
+      </figure>
     )}
     <div class={`px-8 md:px-12 mx-auto max-w-7xl lg:px-32 ${hasHero ? 'pt-8 pb-12' : 'py-12 lg:pt-24'}`}>
       <div class="lg:text-center">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,8 +21,8 @@ const sortedPosts = posts.sort((a, b) => new Date(b.data.pubDate) - new Date(a.d
           description={post.data.description}
           pubDate={post.data.pubDate.toISOString()}
           author={post.data.author}
-          image={post.data.heroImage}
-          alt={post.data.title}
+          image={post.data.heroImage || post.data.image?.url}
+          alt={post.data.image?.alt || post.data.title}
           tags={post.data.tags}
         />
       ))}


### PR DESCRIPTION
## Summary
- show hero images at the top of blog posts
- use hero image as preview thumbnail on the index page
- polish preview card layout for images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afd57ce40483279a06893882cdce3b