### PR TITLE
Display hero images on posts and listing cards

### DIFF
--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -4,8 +4,9 @@ import BaseLayout from "./BaseLayout.astro"; // Ensure path is correct
 import { AstroSeo } from "@astrolib/seo"; // Assuming you still use this
 
 const { frontmatter } = Astro.props;
-const heroSrc = frontmatter.heroImage || frontmatter.image?.url;
-const hasHero = !!heroSrc;
+// Determine hero image for post: prefer `heroImage`, fall back to legacy `image.url`
+const heroSrc = frontmatter.heroImage ?? frontmatter.image?.url;
+const hasHero = Boolean(heroSrc);
 
 // --- SEO Data ---
 const pageTitle = frontmatter.title || "낱말로 쌓은 성성";
@@ -62,15 +63,13 @@ const shouldShowDescription =
 >
   <section>
     {hasHero && (
-      <figure class="mx-auto max-w-7xl mb-8">
-        <img
-          src={heroSrc}
-          alt={frontmatter.image?.alt || frontmatter.title || '게시글 대표 이미지'}
-          class="w-full h-auto object-cover object-center rounded-lg"
-          loading="lazy"
-          onerror="this.style.display='none';"
-        />
-      </figure>
+      <img
+        src={heroSrc}
+        alt={frontmatter.image?.alt || frontmatter.title || '게시글 대표 이미지'}
+        class="mx-auto mb-8 w-full max-w-7xl h-auto object-cover object-center rounded-lg"
+        loading="lazy"
+        onerror="this.style.display='none';"
+      />
     )}
     <div class={`px-8 md:px-12 mx-auto max-w-7xl lg:px-32 ${hasHero ? 'pt-8 pb-12' : 'py-12 lg:pt-24'}`}>
       <div class="lg:text-center">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,18 +14,22 @@ const sortedPosts = posts.sort((a, b) => new Date(b.data.pubDate) - new Date(a.d
 
   <section class="mx-auto mt-12 max-w-7xl px-8 md:px-12 lg:px-32">
     <ul class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-      {sortedPosts.map((post) => (
-        <EntriesOne
-          url={`/posts/${post.slug}`}
-          title={post.data.title}
-          description={post.data.description}
-          pubDate={post.data.pubDate.toISOString()}
-          author={post.data.author}
-          image={post.data.heroImage || post.data.image?.url}
-          alt={post.data.image?.alt || post.data.title}
-          tags={post.data.tags}
-        />
-      ))}
+      {sortedPosts.map((post) => {
+        const imageUrl = post.data.heroImage ?? post.data.image?.url;
+        const altText = post.data.image?.alt || post.data.title;
+        return (
+          <EntriesOne
+            url={`/posts/${post.slug}`}
+            title={post.data.title}
+            description={post.data.description}
+            pubDate={post.data.pubDate.toISOString()}
+            author={post.data.author}
+            image={imageUrl}
+            alt={altText}
+            tags={post.data.tags}
+          />
+        );
+      })}
     </ul>
   </section>
 </BaseLayout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,7 +4,8 @@ import EntriesOne from "@/components/entries/EntriesOne.astro";
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-  const allPosts = await getCollection('blog'); // 👈 Replace 'blog' with your actual collection name
+  // Build tag pages from the `posts` collection
+  const allPosts = await getCollection('posts');
 
   const tagsData = {};
   allPosts.forEach(post => {
@@ -57,10 +58,10 @@ const { posts } = Astro.props;
               url={"/posts/" + post.slug}
               title={post.data.title}
               description={post.data.description}
-              alt={post.data.title}
+              alt={post.data.image?.alt || post.data.title}
               pubDate={post.data.pubDate.toString().slice(0, 10)}
               author={post.data.author}
-              image={post.data.image.url}
+              image={post.data.heroImage ?? post.data.image?.url}
               tags={post.data.tags}
             />
           ))


### PR DESCRIPTION
## Summary
- Render `heroImage` at the top of post pages with fallback to legacy images
- Pass `heroImage` to post listing cards on home and tag pages
- Generate tag pages from the `posts` collection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b0584ff7708327919f3d601b076ba5